### PR TITLE
Better error handling.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -362,6 +362,8 @@ int main(int argc, char ** argv){
     dupprintf("[SCORE%s] Bandwidth %f GB/s : IOPS %f kiops : TOTAL %f\n",
       opt.is_valid_run ? "" : "-invalid",
       scores[IO500_SCORE_BW], scores[IO500_SCORE_MD], overall_score);
+
+    printf("\nThe result files are stored in the directory: %s\n", opt.resdir);
   }
 
   for(int i=0; i < IO500_PHASES; i++){

--- a/src/phase_find.c
+++ b/src/phase_find.c
@@ -60,6 +60,10 @@ static double run(void){
 
     // pfind supports stonewalling timer -s, but ignore for now
     pfind_find_results_t * res = pfind_find(of.pfind_o);
+    if(! res){
+      INVALID("PFind returned with an error, this is invalid.\n")
+      return 0.0;
+    }
     of.pfind_res = pfind_aggregrate_results(res);
 
     if(rank == 0){


### PR DESCRIPTION
Print a better error message when the `find` phase fails.

Print the results directory at the end of the test run.