### PR TITLE
Fix backend

### DIFF
--- a/include/io500-opt.h
+++ b/include/io500-opt.h
@@ -26,7 +26,8 @@ typedef struct{
   int timestamp_resdir;
   int timestamp_datadir;
 
-  IOR_param_t aiori_params;
+  aiori_xfer_hint_t backend_hints;
+  aiori_mod_opt_t * backend_opt;
   ior_aiori_t const * aiori;
 } io500_opt_t;
 

--- a/include/io500-util.h
+++ b/include/io500-util.h
@@ -71,7 +71,7 @@ void u_create_datadir(char const * dir);
 void u_purge_datadir(char const * dir);
 void u_purge_file(char const * file);
 
-void u_create_dir_recursive(char const * dir, char const * api);
+void u_create_dir_recursive(char const * dir, ior_aiori_t const * api);
 
 // invoke an external shell command
 void u_call_cmd(char const * command);

--- a/io500.sh
+++ b/io500.sh
@@ -111,11 +111,11 @@ function main {
   [ $(get_ini_global_param timestamp-datadir True) != "False" ] &&
     ts="$timestamp" || ts="io500"
   # working directory where the test files will be created
-  export io500_workdir=$(get_ini_global_param datadir $PWD/datafiles)/$ts-app
+  export io500_workdir=$(get_ini_global_param datadir $PWD/datafiles)/$ts
   [ $(get_ini_global_param timestamp-resultdir True) != "False" ] &&
     ts="$timestamp" || ts="io500"
   # the directory where the output results will be kept
-  export io500_resultdir=$(get_ini_global_param resultdir $PWD/results)/$ts-app
+  export io500_resultdir=$(get_ini_global_param resultdir $PWD/results)/$ts
 
   setup_directories
   setup_paths

--- a/prepare.sh
+++ b/prepare.sh
@@ -7,9 +7,8 @@ echo It will also attempt to build the benchmarks
 echo It will output OK at the end if builds succeed
 echo
 
-IOR_HASH=2de42103112ec
-IO500_HASH=48eb1880e92d
-#PFIND_HASH=9d77056adce6
+IOR_HASH=8f14166a7939
+PFIND_HASH=9d77056adce6
 
 INSTALL_DIR=$PWD
 BIN=$INSTALL_DIR/bin

--- a/src/main.c
+++ b/src/main.c
@@ -84,24 +84,21 @@ static void init_dirs(void){
     UMPI_CHECK(MPI_Bcast(opt.timestamp, 30, MPI_CHAR, 0, MPI_COMM_WORLD));
   }
 
-  char resdir[PATH_MAX];
   if(opt.timestamp_resdir){
-    sprintf(resdir, "%s/%s-app", opt.resdir, opt.timestamp);
-  }else{
-    sprintf(resdir, "%s/io500-app", opt.resdir);
+    char resdir[PATH_MAX];
+    sprintf(resdir, "%s/%s", opt.resdir, opt.timestamp);
+    opt.resdir = strdup(resdir);
   }
-  opt.resdir = strdup(resdir);
 
   if(opt.timestamp_datadir){
-    sprintf(resdir, "%s/%s-app", opt.datadir, opt.timestamp);
-  }else{
-    sprintf(resdir, "%s/io500-app", opt.datadir);
+    char resdir[PATH_MAX];
+    sprintf(resdir, "%s/%s", opt.datadir, opt.timestamp);
+    opt.datadir = strdup(resdir);
   }
-  opt.datadir = strdup(resdir);
 
   if(opt.rank == 0){
-    u_create_dir_recursive(opt.resdir, "POSIX");
-
+    ior_aiori_t const * posix = aiori_select("POSIX");
+    u_create_dir_recursive(opt.resdir, posix);
     u_create_datadir("");
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -330,10 +330,10 @@ int main(int argc, char ** argv){
 
         char score_str[40];
         sprintf(score_str, "%f", score);
-        dupprintf("[RESULT%s] %20s %15s %s : time %.3f seconds\n",
-		  phase->type == IO500_PHASE_WRITE && runtime < IO500_MINWRITE ?
+        dupprintf("[RESULT%s] %20s %15s %s : time %.3f seconds\n", phase->score == 0.0 ||
+		  (phase->type == IO500_PHASE_WRITE && runtime < IO500_MINWRITE) ?
 			"-invalid" : "",
-		  phase->name, score_str, phase->name[0] == 'i' ? "GiB/s " : "kIOPS", runtime);
+		  phase->name, score_str, phase->name[0] == 'i' ? "GiB/s" : "kIOPS", runtime);
       }
       u_hash_update_key_val_dbl(& score_hash, phase->name, score);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -24,16 +24,17 @@ static void init_dirs(void){
   // check selected API, might be followed by API options
   char * api = strdup(opt.api);
   char * token = strstr(api, " ");
+
+  option_help options [] = {
+    LAST_OPTION
+  };
+  options_all_t * global_options = airoi_create_all_module_options(options);
   if(token){
     *token = '\0';
     opt.apiArgs = strdup(opt.api);
     opt.api = api;
 
     // parse the API options, a bit cumbersome at the moment
-    option_help options [] = {
-      LAST_OPTION
-    };
-    options_all_t * global_options = airoi_create_all_module_options(options);
     // find the next token for all the APIs
     token++;
     for(char * p = token ; ; p++){
@@ -62,8 +63,12 @@ static void init_dirs(void){
     }
   }
   opt.aiori = aiori_select(opt.api);
+  opt.aiori_params.backend_options = airoi_update_module_options(opt.aiori, global_options);
   if(opt.aiori == NULL){
     FATAL("Could not load AIORI backend for %s with options: %s\n", opt.api, opt.apiArgs);
+  }
+  if(opt.aiori->check_params){
+    opt.aiori->check_params(& opt.aiori_params);
   }
   if (opt.aiori->initialize){
     opt.aiori->initialize();

--- a/src/phase_find.c
+++ b/src/phase_find.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <mpi.h>
 #include <string.h>
+#include <errno.h>
 
 
 #include <pfind-options.h>

--- a/src/phase_find.c
+++ b/src/phase_find.c
@@ -12,7 +12,7 @@ typedef struct{
   char * ext_args;
   char * ext_mpi;
   int nproc;
-
+  int no_run;
   char * command;
 
   pfind_options_t * pfind_o;
@@ -29,6 +29,8 @@ typedef struct{
 static opt_find of;
 
 static double run(void){
+  if(of.no_run == 1) return 0.0;
+
   int ret = 0;
 
   PRINT_PAIR("exe", "%s\n", of.command);
@@ -161,12 +163,14 @@ static ini_option_t option[] = {
   {"external-mpi-args", "Startup arguments for external scripts, some MPI's may not support this!", 0, INI_STRING, "", & of.ext_mpi},
   {"external-extra-args", "Extra arguments for the external scripts", 0, INI_STRING, "", & of.ext_args},
   {"nproc", "Set the number of processes for pfind/the external script", 0, INI_UINT, NULL, & of.nproc},
+  {"noRun", "Disable running of this phase", 0, INI_BOOL, NULL, & of.no_run},
   {"pfind-queue-length", "Pfind queue length", 0, INI_INT, "10000", & of.pfind_queue_length},
   {"pfind-steal-next", "Pfind Steal from next", 0, INI_BOOL, "FALSE", & of.pfind_steal_from_next},
   {"pfind-parallelize-single-dir-access-using-hashing", "Parallelize the readdir by using hashing. Your system must support this!", 0, INI_BOOL, "FALSE", &  of.pfind_par_single_dir_access_hash},
   {NULL} };
 
 static void validate(void){
+  if(of.no_run == 1) return;
   if(of.ext_find){
     struct stat sb;
     int ret = stat(of.ext_find, & sb);

--- a/src/phase_find.c
+++ b/src/phase_find.c
@@ -42,7 +42,7 @@ static double run(void){
   if(opt.rank == 0){
     // check the existance of the timestamp file just for correctness
     char timestamp_file[PATH_MAX];
-    sprintf(timestamp_file, "%s/timestampfile", opt.datadir);
+    sprintf(timestamp_file, "%s/timestampfile", opt.resdir);
     FILE * f = fopen(timestamp_file, "r");
     if(! f){
       FATAL("Couldn't open timestampfile: %s\n", timestamp_file);
@@ -177,7 +177,7 @@ static void validate(void){
       FATAL("The external-script must be a executable file %s\n", of.ext_find);
     }
     char arguments[1024];
-    sprintf(arguments, "%s -newer %s/timestampfile -size 3901c -name \"*01*\"", opt.datadir, opt.datadir);
+    sprintf(arguments, "%s -newer %s/timestampfile -size 3901c -name \"*01*\"", opt.datadir, opt.resdir);
 
     char command[2048];
     sprintf(command, "%s %s %s %s", of.ext_mpi, of.ext_find, of.ext_args, arguments);
@@ -195,7 +195,7 @@ static void validate(void){
     u_argv_push(argv, "./pfind");
     u_argv_push(argv, opt.datadir);
     u_argv_push(argv, "-newer");
-    u_argv_push_printf(argv, "%s/timestampfile", opt.datadir);
+    u_argv_push_printf(argv, "%s/timestampfile", opt.resdir);
     u_argv_push(argv, "-size");
     u_argv_push(argv, "3901c");
     u_argv_push(argv, "-name");

--- a/src/phase_ior_easy.c
+++ b/src/phase_ior_easy.c
@@ -34,7 +34,9 @@ static void validate(void){
 
 static void cleanup(void){
   if( ! opt.dry_run && opt.rank == 0){
-    u_purge_file("ior-easy/stonewall");
+    char filename[PATH_MAX];
+    sprintf(filename, "%s/ior-easy.stonewall", opt.resdir);
+    unlink(filename);
 
     if(! ior_easy_o.filePerProc){
       u_purge_file("ior-easy/ior_file_easy");
@@ -66,7 +68,7 @@ void ior_easy_add_params(u_argv_t * argv){
   u_argv_push(argv, "-o");
   u_argv_push_printf(argv, "%s/ior-easy/ior_file_easy", opt.datadir);
   u_argv_push(argv, "-O");
-  u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-easy/stonewall", opt.datadir );
+  u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-easy.stonewall", opt.resdir);
   u_argv_push(argv, "-t");
   u_argv_push(argv, d.transferSize);
   u_argv_push(argv, "-b");

--- a/src/phase_ior_hard.c
+++ b/src/phase_ior_hard.c
@@ -33,8 +33,10 @@ static void validate(void){
 
 static void cleanup(void){
   if( ! opt.dry_run && opt.rank == 0){
+    char filename[PATH_MAX];
+    sprintf(filename, "%s/ior-hard.stonewall", opt.resdir);
+    unlink(filename);
     u_purge_file("ior-hard/file");
-    u_purge_file("ior-hard/stonewall");
   }
   if(opt.rank == 0){
     u_purge_datadir("ior-hard");
@@ -59,7 +61,7 @@ void ior_hard_add_params(u_argv_t * argv){
   u_argv_push(argv, "-o");
   u_argv_push_printf(argv, "%s/ior-hard/file", opt.datadir);
   u_argv_push(argv, "-O");
-  u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-hard/stonewall", opt.datadir );
+  u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-hard.stonewall", opt.resdir );
   u_argv_push(argv, "-O");
   u_argv_push(argv, "stoneWallingWearOut=1");
   u_argv_push(argv, "-t");

--- a/src/phase_ior_hard_write.c
+++ b/src/phase_ior_hard_write.c
@@ -19,7 +19,6 @@ static opt_ior_hard_write o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
-  {"posix.odirect", "Use ODirect", 0, INI_BOOL, NULL, & o.odirect},
   {"hintsFileName", "Filename for hints file", 0, INI_STRING, NULL, & o.hintsFileName},
   {NULL} };
 
@@ -37,7 +36,6 @@ static double run(void){
   u_argv_push_printf(argv, "%d", opt.stonewall);
   u_argv_push_default_if_set(argv, "-U", d.hintsFileName, o.hintsFileName);
   u_argv_push_default_if_set_api_options(argv, "-a", d.api, o.api);
-  u_argv_push_default_if_set_bool(argv, "--posix.odirect", d.odirect, o.odirect);
 
   o.command = u_flatten_argv(argv);
 

--- a/src/phase_mdtest_easy.c
+++ b/src/phase_mdtest_easy.c
@@ -21,7 +21,9 @@ static void validate(void){
 
 static void cleanup(void){
   if( ! opt.dry_run && opt.rank == 0){
-    u_purge_file("mdtest-easy-stonewall");
+    char filename[PATH_MAX];
+    sprintf(filename, "%s/mdtest-easy.stonewall", opt.resdir);
+    unlink(filename);
     u_purge_datadir("mdtest-easy");
   }
 }
@@ -41,7 +43,7 @@ void mdtest_easy_add_params(u_argv_t * argv){
   u_argv_push(argv, "-d");
   u_argv_push_printf(argv, "%s/mdtest-easy", opt.datadir);
   u_argv_push(argv, "-x");
-  u_argv_push_printf(argv, "%s/mdtest-easy-stonewall", opt.datadir);
+  u_argv_push_printf(argv, "%s/mdtest-easy.stonewall", opt.resdir);
 }
 
 u_phase_t p_mdtest_easy = {

--- a/src/phase_mdtest_hard.c
+++ b/src/phase_mdtest_hard.c
@@ -21,7 +21,9 @@ static void validate(void){
 
 static void cleanup(void){
   if( ! opt.dry_run && opt.rank == 0){
-    u_purge_file("mdtest-hard-stonewall");
+    char filename[PATH_MAX];
+    sprintf(filename, "%s/mdtest-hard.stonewall", opt.resdir);
+    unlink(filename);
     u_purge_datadir("mdtest-hard");
   }
 }
@@ -44,7 +46,7 @@ void mdtest_hard_add_params(u_argv_t * argv){
   u_argv_push(argv, "-d");
   u_argv_push_printf(argv, "%s/mdtest-hard", opt.datadir);
   u_argv_push(argv, "-x");
-  u_argv_push_printf(argv, "%s/mdtest-hard-stonewall", opt.datadir);
+  u_argv_push_printf(argv, "%s/mdtest-hard.stonewall", opt.resdir);
 }
 
 u_phase_t p_mdtest_hard = {

--- a/src/phase_timestamp.c
+++ b/src/phase_timestamp.c
@@ -16,15 +16,13 @@ static double run(void){
   if(opt.rank != 0) return 0;
 
   char timestamp_file[2048];
-  sprintf(timestamp_file, "%s/timestampfile", opt.datadir);
+  sprintf(timestamp_file, "%s/timestampfile", opt.resdir);
   INFO_PAIR("timestamp-file", "%s\n", timestamp_file);
-
   FILE * f = fopen(timestamp_file, "w");
   if(! f){
-    FATAL("Couldn't write timestampfile: %s\n", timestamp_file);
+    FATAL("Couldn't open timestampfile: %s\n", timestamp_file);
   }
   fclose(f);
-
   return 0;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -74,10 +74,10 @@ void u_create_datadir(char const * dir){
   }
   char d[2048];
   sprintf(d, "%s/%s", opt.datadir, dir);
-  u_create_dir_recursive(d, opt.api);
+  u_create_dir_recursive(d, opt.aiori);
 }
 
-void u_create_dir_recursive(char const * dir, char const * api){
+void u_create_dir_recursive(char const * dir, ior_aiori_t const * api){
   char * d = strdup(dir);
   char outdir[2048];
   char * wp = outdir;
@@ -94,7 +94,7 @@ void u_create_dir_recursive(char const * dir, char const * api){
     int ret = stat(outdir, & sb);
     if(ret != 0){
       DEBUG_INFO("Creating dir %s\n", outdir);
-      ret = opt.aiori->mkdir(outdir, S_IRWXU, NULL);
+      ret = api->mkdir(outdir, S_IRWXU, NULL);
       if(ret != 0){
         FATAL("Couldn't create directory %s (Error: %s)\n", outdir, strerror(errno));
       }

--- a/src/util.c
+++ b/src/util.c
@@ -150,7 +150,7 @@ static void push_api_args(u_argv_t * argv, char const * var){
       if(strncasecmp(buff, t, len) == 0){
         u_argv_push(argv, t);
       }else{
-        FATAL("Provided API option %s appears to be no API supported version", t);
+        FATAL("Provided API option %s appears to be no API supported version\n", t);
       }
     }
   }

--- a/src/util.c
+++ b/src/util.c
@@ -58,14 +58,14 @@ void u_purge_datadir(char const * dir){
   sprintf(d, "%s/%s", opt.datadir, dir);
   DEBUG_INFO("Removing dir %s\n", d);
 
-  opt.aiori->rmdir(d, & opt.aiori_params);
+  opt.aiori->rmdir(d, opt.backend_opt);
 }
 
 void u_purge_file(char const * file){
   char f[2048];
   sprintf(f, "%s/%s", opt.datadir, file);
   DEBUG_INFO("Removing file %s\n", f);
-  opt.aiori->delete(f, & opt.aiori_params);
+  opt.aiori->delete(f, opt.backend_opt);
 }
 
 void u_create_datadir(char const * dir){

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -4,6 +4,8 @@
 #include <io500-util.h>
 #include <io500-phase.h>
 
+#include <ior.h>
+
 #include <phase-definitions.h>
 
 // Dummy prototypes to satisfy need for depending modules

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -14,7 +14,7 @@ double GetTimeStamp(void){ return 0; }
 void pfind_parse_args(void){}
 IOR_test_t * ior_run(int argc, char **argv, MPI_Comm world_com, FILE * out_logfile){ return NULL; }
 void mdtest_run(void){}
-
+FILE* out_logfile;
 FILE* file_out;
 
 int main(int argc, char ** argv){

--- a/test/ini-test.c
+++ b/test/ini-test.c
@@ -3,11 +3,12 @@
 
 #include <io500-util.h>
 
-FILE * file_out;
+FILE* file_out;
+FILE* out_logfile;
 
 int main(void){
   file_out = stdout;
-  
+
   int ret;
   {
     ini_section_t * testsec[] = {NULL};


### PR DESCRIPTION
Patch series from Julian to improve usage of non-POSIX backends.   I refactored it to merge bug fixes into the original patches that add the changes.

Each patch updates the `prepare.sh` file with the version of IOR that it can build against, so that each patch can at least run a basic test.

I also enabled the `$PFIND_HASH` usage when running `prepare.sh`, as requested by [prepare.sh should checkout specific commit of pfind](https://github.com/VI4IO/io500-app/issues/17).