### PR TITLE
add default value to datadir through the --list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ Detailed help for the available options is provided when running:
 
 The benchmark output the commands it would run (equivalence of command line invocations of ior/mdtest). Use --dry-run to not invoke any command.
 
-Three .ini files are provided, the config-minimal.ini and the config-some.ini.
-  - The minimal example contains the only mandatory parameter, the data directory. It also sets the stonewalling to 1 for testing.
-  - The config-some illustrates the setting of various options. For more details, run ./io500 -h.
-  - The config-all shows all available configuration options and their default values.  This is generated from ./io500 --list.
+In order to create a new INI file with all the options, you can execute:
+
+    $ ./io500 --list > config-all.ini
+
+The config-some illustrates the setting of various options. For more details, run ./io500 -h.
 
 To see the currently active options, run:
 

--- a/src/phase_opt.c
+++ b/src/phase_opt.c
@@ -3,7 +3,7 @@
 io500_opt_t opt;
 
 static ini_option_t option[] = {
-  {"datadir", "The directory where the IO500 runs", 1, INI_STRING, NULL, & opt.datadir},
+  {"datadir", "The directory where the IO500 runs", 1, INI_STRING, "./datafiles", & opt.datadir},
   {"timestamp-datadir", "The data directory is suffixed by a timestamp. Useful for running several IO500 tests concurrently.", 0, INI_BOOL, "TRUE", & opt.timestamp_datadir},
   {"resultdir", "The result directory.", 0, INI_STRING, "./results", & opt.resdir},
   {"timestamp-resultdir", "The result directory is suffixed by a timestamp. Useful for running several IO500 tests concurrently.", 0, INI_BOOL, "TRUE", & opt.timestamp_resdir},


### PR DESCRIPTION
the command ./io500 --list produces a new INI file without a value for the datadir variable. I did change its value to ./datafiles, thus the new INI file can be used directly without modifications. 

I did correct also the README.md file 