### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+# For more info about this file, please see https://docs.github.com/en/enterprise/2.18/user/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# all repos in the io500 org.
+*       @adilger @gflofst @gmarkomanolis @johnbent @JulianKunkel


### PR DESCRIPTION
Signed-off-by: John Bent <john.bent@seagate.com>

This makes it so we are all automatically added as reviewers.  I thought it would work at the root of the org but it apparently needs to be done for each individual repo.