### PR TITLE
Add missing INI section.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -312,7 +312,7 @@ int main(int argc, char ** argv){
     fwrite(ini_data, strlen(ini_data), 1, fd);
     fclose(fd);
   }
-
+  fprintf(file_out, "[run]\n");
   PRINT_PAIR("version", "%s\n", VERSION);
   print_cfg_hash(file_out, cfg);
   PRINT_PAIR("result-dir", "%s\n", opt.resdir);


### PR DESCRIPTION
Ensure that the result.txt file is a proper section, e.g.:
[run]
version         = io500-isc21-13
config-hash     = 99FCE1C5
result-dir      = ./results
mode            = standard

