### PR TITLE
Added --dataPacketType option to io500 script

### DIFF
--- a/include/io500-util.h
+++ b/include/io500-util.h
@@ -102,6 +102,7 @@ void u_argv_push(u_argv_t * argv, char const * str);
 void u_argv_push_default_if_set(u_argv_t * argv, char * const arg, char const * dflt, char const * var);
 /* if the first argument is the API, subsequent options provided with --api.option will be permitted*/
 void u_argv_push_default_if_set_api_options(u_argv_t * argv, char * const arg, char const * dflt, char const * var);
+void u_argv_push_default_if_set_dataPacketType(u_argv_t * argv, char * const arg, char const * dflt, char const * var);
 void u_argv_push_default_if_set_bool(u_argv_t * argv, char * const arg, int dflt, int var);
 
 void u_argv_push_printf(u_argv_t * argv, char const * format, ...)

--- a/src/phase_ior.h
+++ b/src/phase_ior.h
@@ -13,6 +13,7 @@ typedef struct{
   char * transferSize;
   char * blockSize;
   int verbosity;
+  char * dataPacketType;
 } opt_ior_easy;
 
 extern opt_ior_easy ior_easy_o;
@@ -24,6 +25,7 @@ typedef struct{
 
   int segments;
   int verbosity;
+  char * dataPacketType;
 } opt_ior_hard;
 
 extern opt_ior_hard ior_hard_o;

--- a/src/phase_ior_easy.c
+++ b/src/phase_ior_easy.c
@@ -14,6 +14,7 @@ static ini_option_t option[] = {
   {"uniqueDir", "Use unique directory per file per process", 0, INI_BOOL, "FALSE", & ior_easy_o.uniqueDir},
   {"run", "Run this phase", 0, INI_BOOL, "TRUE", & ior_easy_o.run},
   {"verbosity", "The verbosity level", 0, INI_INT, 0, & ior_easy_o.verbosity},
+  {"dataPacketType", "Type of packet that will be created [offset|incompressible|timestamp]", 0, INI_STRING, NULL, & ior_easy_o.dataPacketType},
   {NULL} };
 
 static void validate(void){

--- a/src/phase_ior_easy_write.c
+++ b/src/phase_ior_easy_write.c
@@ -8,6 +8,7 @@
 
 typedef struct{
   char * api;
+  char * dataPacketType;
 
   char * command;
   IOR_point_t * res;
@@ -17,6 +18,7 @@ static opt_ior_easy_write o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
+  {"dataPacketType", "Type of packet that will be created [offset|incompressible|timestamp]", 0, INI_STRING, NULL, & o.dataPacketType},
   {NULL} };
 
 static void validate(void){
@@ -34,6 +36,7 @@ static double run(void){
   u_argv_push(argv, "-O");
   u_argv_push(argv, "stoneWallingWearOut=1");
   u_argv_push_default_if_set_api_options(argv, "-a", d.api, o.api);
+  u_argv_push_default_if_set_dataPacketType(argv, "-l", d.dataPacketType, o.dataPacketType);
   u_argv_push(argv, "-O");
   u_argv_push_printf(argv, "saveRankPerformanceDetailsCSV=%s/ior-easy-write.csv", opt.resdir);
 

--- a/src/phase_ior_hard.c
+++ b/src/phase_ior_hard.c
@@ -12,6 +12,7 @@ static ini_option_t option[] = {
   {"collective", "Collective operation (for supported backends)", 0, INI_BOOL, NULL, & ior_hard_o.collective},
   {"run", "Run this phase", 0, INI_BOOL, "TRUE", & ior_hard_o.run},
   {"verbosity", "The verbosity level", 0, INI_INT, 0, & ior_hard_o.verbosity},
+  {"dataPacketType", "Type of packet that will be created [offset|incompressible|timestamp]", 0, INI_STRING, NULL, & ior_hard_o.dataPacketType},
   {NULL} };
 
 

--- a/src/phase_ior_hard_write.c
+++ b/src/phase_ior_hard_write.c
@@ -8,6 +8,7 @@
 
 typedef struct{
   char * api;
+  char * dataPacketType;
 
   char * command;
   IOR_point_t * res;
@@ -18,6 +19,7 @@ static opt_ior_hard_write o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
+  {"dataPacketType", "Type of packet that will be created [offset|incompressible|timestamp]", 0, INI_STRING, NULL, & o.dataPacketType},
   {"collective", "Collective operation (for supported backends)", 0, INI_BOOL, NULL, & o.collective},
   {NULL} };
 
@@ -37,6 +39,7 @@ static double run(void){
   u_argv_push_default_if_set_api_options(argv, "-a", d.api, o.api);
   u_argv_push(argv, "-O");
   u_argv_push_printf(argv, "saveRankPerformanceDetailsCSV=%s/ior-hard-write.csv", opt.resdir);
+  u_argv_push_default_if_set_dataPacketType(argv, "-l", d.dataPacketType, o.dataPacketType);
   u_argv_push(argv, "-O");
   u_argv_push(argv, "stoneWallingWearOut=1");
   

--- a/src/util.c
+++ b/src/util.c
@@ -168,6 +168,30 @@ static void push_api_args(u_argv_t * argv, char const * var){
   free(str);
 }
 
+static void push_dpt_args(u_argv_t * argv, char const * var){
+  char * str = strdup(var);
+  char * saveptr;
+  char * t = strtok_r(str, " ", & saveptr);
+  u_argv_push(argv, str); // this is the dataPacketType
+  if(t){
+    int len = strlen(str) + 3;
+    char buff[len + 1];
+    sprintf(buff, "--%s.", str);
+    while(true){
+      t = strtok_r(NULL, " ", & saveptr);
+      if(! t){
+        break;
+      }
+      if(strncasecmp(buff, t, len) == 0){
+        u_argv_push(argv, t);
+      }else{
+        FATAL("Provided dataPacketType option %s is invalid\n", t);
+      }
+    }
+  }
+  free(str);
+}
+
 void u_argv_push_default_if_set_api_options(u_argv_t * argv, char * const arg, char const * dflt, char const * var){
   if(var != INI_UNSET_STRING){
     u_argv_push(argv, arg);
@@ -183,6 +207,19 @@ void u_argv_push_default_if_set_api_options(u_argv_t * argv, char * const arg, c
     }else{
       u_argv_push(argv, opt.api);
     }
+  }
+}
+
+void u_argv_push_default_if_set_dataPacketType(u_argv_t * argv, char * const arg, char const * dflt, char const * var){
+  if(var != INI_UNSET_STRING){
+    u_argv_push(argv, arg);
+    push_dpt_args(argv, var);
+  }else if(dflt != INI_UNSET_STRING){
+    u_argv_push(argv, arg);
+    push_dpt_args(argv, dflt);
+  }else{
+    // add generic args
+    u_argv_push(argv, arg);
   }
 }
 


### PR DESCRIPTION
This PR adds the --dataPacketType option to the io500 script, specifically for ior_easy and ior_hard. It does not yet implement the option for other portions of the benchmark. 