### PR TITLE
Support files-per-dir by disabling stonewalling. 

### DIFF
--- a/src/phase_mdtest_hard_write.c
+++ b/src/phase_mdtest_hard_write.c
@@ -26,11 +26,17 @@ static double run(void){
   mdtest_hard_add_params(argv);
   u_argv_push(argv, "-C");
   u_argv_push(argv, "-Y");
-  u_argv_push(argv, "-W");
-  u_argv_push_printf(argv, "%d", opt.stonewall);
+  
+  opt_mdtest_hard d = mdtest_hard_o;
+  if(! (d.g.files_per_dir != INI_UNSET_UINT64 && d.g.files_per_dir > 0)){
+    // Must disable stonewalling for supporting this option -- for now!
+    u_argv_push(argv, "-W");
+    u_argv_push_printf(argv, "%d", opt.stonewall);
+    WARNING("stonewalling disabled in order to support -I option. Make sure your number of elements is big enough to meet the runtime limits!");
+  }
+  
   u_argv_push_printf(argv, "--saveRankPerformanceDetails=%s/mdtest-hard-write.csv", opt.resdir);
 
-  opt_mdtest_hard d = mdtest_hard_o;
   mdtest_add_generic_params(argv, & d.g, & o.g);
 
   if(opt.dry_run || o.g.run == 0 || mdtest_hard_o.g.run == 0){


### PR DESCRIPTION
Note this is only allowed if needed and the committee approves.