### PR TITLE
Calculate score even for skipped phases and 0 values. Add NoRun to IOR phases. #42

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -134,9 +134,11 @@ static double calc_score(double scores[IO500_SCORE_LAST], int extended, uint32_t
     for(int i=0; i < IO500_PHASES; i++){
       if(phases[i]->group == g && (extended || ! (phases[i]->type & IO500_PHASE_FLAG_OPTIONAL)) ){
         double t = phases[i]->score;
+        if(t <= 0){
+          continue;
+        }
         score *= t;
-        if(numbers > 0)
-          p += sprintf(p, " * ");
+        p += sprintf(p, " * ");
         numbers++;
         p += sprintf(p, "%.8f", t);
       }

--- a/src/phase_ior_easy_read.c
+++ b/src/phase_ior_easy_read.c
@@ -6,6 +6,7 @@
 #include <phase_ior.h>
 
 typedef struct{
+  int run;
   char * api;
 
   char * command;
@@ -16,6 +17,7 @@ static opt_ior_easy_read o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
+  {"run", "Run this phase", 0, INI_BOOL, "TRUE", & o.run},  
   {NULL} };
 
 
@@ -38,7 +40,7 @@ static double run(void){
   o.command = u_flatten_argv(argv);
 
   PRINT_PAIR("exe", "%s\n", o.command);
-  if(opt.dry_run || d.run == 0){
+  if(opt.dry_run || d.run == 0 || o.run == 0){
     u_argv_free(argv);
     return 0;
   }

--- a/src/phase_ior_easy_write.c
+++ b/src/phase_ior_easy_write.c
@@ -7,6 +7,7 @@
 #include <phase_ior.h>
 
 typedef struct{
+  int run;
   char * api;
 
   char * command;
@@ -17,6 +18,7 @@ static opt_ior_easy_write o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
+  {"run", "Run this phase", 0, INI_BOOL, "TRUE", & o.run},  
   {NULL} };
 
 static void validate(void){
@@ -40,7 +42,7 @@ static double run(void){
   o.command = u_flatten_argv(argv);
 
   PRINT_PAIR("exe", "%s\n", o.command);
-  if(opt.dry_run || d.run == 0){
+  if(opt.dry_run || d.run == 0 || o.run == 0){
     u_argv_free(argv);
     return 0;
   }

--- a/src/phase_ior_hard_read.c
+++ b/src/phase_ior_hard_read.c
@@ -6,6 +6,7 @@
 #include <phase_ior.h>
 
 typedef struct{
+  int run;
   char * api;
 
   char * command;
@@ -18,6 +19,7 @@ static opt_ior_hard_read o;
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
   {"collective", "Collective operation (for supported backends)", 0, INI_BOOL, NULL, & o.collective},
+  {"run", "Run this phase", 0, INI_BOOL, "TRUE", & o.run},  
   {NULL} };
 
 
@@ -41,7 +43,7 @@ static double run(void){
   o.command = u_flatten_argv(argv);
 
   PRINT_PAIR("exe", "%s\n", o.command);
-  if(opt.dry_run || d.run == 0){
+  if(opt.dry_run || d.run == 0 || o.run == 0){
     u_argv_free(argv);
     return 0;
   }

--- a/src/phase_ior_hard_write.c
+++ b/src/phase_ior_hard_write.c
@@ -7,6 +7,7 @@
 #include <phase_ior.h>
 
 typedef struct{
+  int run;
   char * api;
 
   char * command;
@@ -19,6 +20,7 @@ static opt_ior_hard_write o;
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
   {"collective", "Collective operation (for supported backends)", 0, INI_BOOL, NULL, & o.collective},
+  {"run", "Run this phase", 0, INI_BOOL, "TRUE", & o.run},  
   {NULL} };
 
 static void validate(void){
@@ -43,7 +45,7 @@ static double run(void){
   o.command = u_flatten_argv(argv);
 
   PRINT_PAIR("exe", "%s\n", o.command);
-  if(opt.dry_run || d.run == 0){
+  if(opt.dry_run || d.run == 0 || o.run == 0){
     u_argv_free(argv);
     return 0;
   }

--- a/src/phase_ior_rnd_read.c
+++ b/src/phase_ior_rnd_read.c
@@ -6,6 +6,7 @@
 #include <phase_ior.h>
 
 typedef struct{
+  int run;
   char * api;
 
   char * command;
@@ -16,6 +17,7 @@ static opt_ior_rnd_read o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
+  {"run", "Run this phase", 0, INI_BOOL, "TRUE", & o.run},  
   {NULL} };
 
 
@@ -38,7 +40,7 @@ static double run(void){
   o.command = u_flatten_argv(argv);
 
   PRINT_PAIR("exe", "%s\n", o.command);
-  if(opt.dry_run || d.run == 0){
+  if(opt.dry_run || d.run == 0 || o.run == 0){
     u_argv_free(argv);
     return 0;
   }

--- a/src/phase_ior_rnd_write.c
+++ b/src/phase_ior_rnd_write.c
@@ -7,6 +7,7 @@
 #include <phase_ior.h>
 
 typedef struct{
+  int run;
   char * api;
 
   char * command;
@@ -17,6 +18,7 @@ static opt_ior_rnd_write o;
 
 static ini_option_t option[] = {
   {"API", "The API to be used", 0, INI_STRING, NULL, & o.api},
+  {"run", "Run this phase", 0, INI_BOOL, "TRUE", & o.run},  
   {NULL} };
 
 static void validate(void){
@@ -56,7 +58,7 @@ static double run(void){
   o.command = u_flatten_argv(argv);
 
   PRINT_PAIR("exe", "%s\n", o.command);
-  if(opt.dry_run || d.run == 0){
+  if(opt.dry_run || d.run == 0 || o.run == 0){
     u_argv_free(argv);
     return 0;
   }


### PR DESCRIPTION
Fixes #42