### PR TITLE
Support for pausing individual benchmarks. 

### DIFF
--- a/config-debug-run.ini
+++ b/config-debug-run.ini
@@ -5,3 +5,5 @@ timestamp-resultdir = FALSE
 
 [debug]
 stonewall-time = 1
+pause-dir = ./pause/
+

--- a/include/io500-opt.h
+++ b/include/io500-opt.h
@@ -14,6 +14,7 @@ typedef struct{
   char * drop_caches_cmd;
 
   int stonewall;
+  char * pause_dir; // if set check for files of the phase
 
   char * datadir;
   char * resdir;

--- a/src/main.c
+++ b/src/main.c
@@ -380,15 +380,43 @@ int main(int argc, char ** argv){
       if(opt.rank == 0)
         u_call_cmd("LANG=C free -m");
     }
-
+  
     MPI_Barrier(MPI_COMM_WORLD);
     if(opt.rank == 0){
       fprintf(file_out, "\n[%s]\n", phase->name);
+      
+      if(opt.pause_dir){
+        // if the file exists
+        char path[2048];
+        int ret; 
+        struct stat statbuf;
+        if(opt.verbosity > 0){
+          PRINT_PAIR_HEADER("t_pause");
+          u_print_timestamp(file_out);
+          fprintf(file_out, "\n");
+        }
+        sprintf(path, "%s/%s", opt.pause_dir, phase->name);
+        fprintf(file_out, "; Checking for pause file %s\n", path);
+        fflush(file_out);
+        while(1){
+          ret = stat(path, & statbuf);
+          if(ret != 0){
+            break;
+          }
+          sleep(1);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+      }
+      
       if(opt.verbosity > 0){
         PRINT_PAIR_HEADER("t_start");
         u_print_timestamp(file_out);
         fprintf(file_out, "\n");
       }
+    }
+
+    if(opt.pause_dir && opt.rank != 0){
+      MPI_Barrier(MPI_COMM_WORLD);
     }
 
     double start = GetTimeStamp();

--- a/src/main.c
+++ b/src/main.c
@@ -301,7 +301,7 @@ int main(int argc, char ** argv){
 
   FILE * res_summary = NULL;
   if(opt.rank == 0){
-    char file[2048];
+    char file[PATH_MAX];
     sprintf(file, "%s/result_summary.txt", opt.resdir);
     res_summary = fopen(file, "w");
     if(! res_summary){
@@ -327,7 +327,7 @@ int main(int argc, char ** argv){
 
   if(opt.rank == 0){
     // create configuration in result directory to ensure it is preserved
-    char file[2048];
+    char file[PATH_MAX];
     sprintf(file, "%s/config.ini", opt.resdir);
     FILE * fd = fopen(file, "w");
     if(! fd){
@@ -387,7 +387,7 @@ int main(int argc, char ** argv){
       
       if(opt.pause_dir){
         // if the file exists
-        char path[2048];
+        char path[PATH_MAX];
         int ret; 
         struct stat statbuf;
         if(opt.verbosity > 0){

--- a/src/main.c
+++ b/src/main.c
@@ -340,6 +340,9 @@ int main(int argc, char ** argv){
   if(opt.dry_run){
     INVALID_RUN("DRY RUN MODE ACTIVATED\n");
   }
+  if(opt.pause_dir){
+    INVALID_RUN("PAUSING BETWEEN RUNS ACTIVATED\n");
+  }
 
   MPI_Barrier(MPI_COMM_WORLD);
   if(opt.verbosity > 0 && opt.rank == 0){

--- a/src/phase_dbg.c
+++ b/src/phase_dbg.c
@@ -5,6 +5,8 @@
 
 static ini_option_t option[] = {
   {"stonewall-time", "For a valid result, the stonewall timer must be set to the value according to the rules. If smaller "DEBUG_OPTION, 0, INI_INT, "300", & opt.stonewall},
+  {"pause-dir", "Pause between phases while in this directory lies a file with the phase name, e.g., easy-create. This can be useful for performance testing, e.g., of tiered storage. At the moment it "DEBUG_OPTION, 0, INI_STRING, NULL, & opt.pause_dir},
+  
   {NULL} };
 
 

--- a/src/phase_find.c
+++ b/src/phase_find.c
@@ -161,7 +161,7 @@ static ini_option_t option[] = {
 static void validate(void){
   if(of.run == 0) return;
   if(of.ext_find){
-    char args[2048];
+    char args[PATH_MAX];
     sprintf(args, "%s -newer %s/timestampfile -size 3901c -name \"*01*\"", opt.datadir, opt.resdir);
     external_find_prepare_arguments(args, & of);
   }else{
@@ -198,7 +198,7 @@ void external_find_prepare_arguments(char * args, opt_find * of){
   if(! (sb.st_mode & S_IXUSR) ){
     FATAL("The external-script must be a executable file %s\n", of->ext_find);
   }
-  char command[2048];
+  char command[PATH_MAX];
   sprintf(command, "%s %s %s %s", of->ext_mpi, of->ext_find, of->ext_args, args);
   of->command = strdup(command);
 

--- a/src/phase_ior_easy.c
+++ b/src/phase_ior_easy.c
@@ -33,7 +33,7 @@ static void cleanup(void){
     }
   }
   if(ior_easy_o.filePerProc){
-      char filename[2048];
+      char filename[PATH_MAX];
       sprintf(filename, "ior-easy/ior_file_easy.%08d", opt.rank);
       u_purge_file(filename);
   }

--- a/src/phase_mdworkbench.c
+++ b/src/phase_mdworkbench.c
@@ -75,7 +75,7 @@ void mdworkbench_add_params(u_argv_t * argv, int is_create){
     mdtest_generic_res* mdtest = mdtest_easy_write_get_result();
     MPI_Bcast(& mdtest->rate, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
-    char file[2048];
+    char file[PATH_MAX];
     sprintf(file, "%s/mdworkbench-size", opt.resdir);
     if (is_create && opt.rank == 0){
       // store the actual processed size, allows easy deletion

--- a/src/phase_timestamp.c
+++ b/src/phase_timestamp.c
@@ -14,7 +14,7 @@ static void validate(void){
 static double run(void){
   if(opt.rank != 0) return 0;
 
-  char timestamp_file[2048];
+  char timestamp_file[PATH_MAX];
   sprintf(timestamp_file, "%s/timestampfile", opt.resdir);
   INFO_PAIR("timestamp-file", "%s\n", timestamp_file);
   FILE * f = fopen(timestamp_file, "w");

--- a/src/util.c
+++ b/src/util.c
@@ -65,7 +65,7 @@ void u_call_cmd(char const * str){
   }
 }
 void u_purge_datadir(char const * dir){
-  char d[2048];
+  char d[PATH_MAX];
   sprintf(d, "%s/%s", opt.datadir, dir);
   DEBUG_INFO("Removing dir %s\n", d);
 
@@ -73,7 +73,7 @@ void u_purge_datadir(char const * dir){
 }
 
 void u_purge_file(char const * file){
-  char f[2048];
+  char f[PATH_MAX];
   sprintf(f, "%s/%s", opt.datadir, file);
   DEBUG_INFO("Removing file %s\n", f);
   opt.aiori->delete(f, opt.backend_opt);
@@ -83,14 +83,14 @@ void u_create_datadir(char const * dir){
   if(opt.rank != 0){
     return;
   }
-  char d[2048];
+  char d[PATH_MAX];
   sprintf(d, "%s/%s", opt.datadir, dir);
   u_create_dir_recursive(d, opt.aiori, opt.backend_opt);
 }
 
 void u_create_dir_recursive(char const * dir, ior_aiori_t const * api, aiori_mod_opt_t * module_options){
   char * d = strdup(dir);
-  char outdir[2048];
+  char outdir[PATH_MAX];
   char * wp = outdir;
   if (dir[0] == '/'){
     wp += sprintf(wp, "/");
@@ -198,7 +198,7 @@ void u_argv_push_default_if_set(u_argv_t * argv, char * const arg, char const * 
 
 
 void u_argv_push_printf(u_argv_t * argv, char const * format, ...){
-  char buff[2048];
+  char buff[PATH_MAX];
   va_list args;
   va_start(args, format);
   vsprintf(buff, format, args);
@@ -207,7 +207,7 @@ void u_argv_push_printf(u_argv_t * argv, char const * format, ...){
 }
 
 char * u_flatten_argv(u_argv_t * argv){
-  char command[2048];
+  char command[PATH_MAX];
   char * p = command;
   *p = '\0';
   for(int i = 0; i < argv->size; i++){
@@ -239,7 +239,7 @@ void u_print_timestamp(FILE * out){
 FILE * u_res_file_prep(char const * name){
   FILE * out = stdout;
   if(opt.rank == 0){
-    char fname[2048];
+    char fname[PATH_MAX];
     sprintf(fname, "%s/%s.txt", opt.resdir, name);
     INFO_PAIR("result-file", "%s\n", fname);
     out = fopen(fname, "w");


### PR DESCRIPTION
This may be used for testing of e.g., tiered storage.

Setting the pause-dir directory option, the rank0 will check before starting each phase if a file exists in the pause dir. If it does, it will not start. For debugging, it will print a message for each phase into the summary.txt file:
; Checking for pause file ./pause/mdtest-hard-write

