### PR TITLE
Fix: aiori->delete is now aiori->remove

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -76,7 +76,7 @@ void u_purge_file(char const * file){
   char f[PATH_MAX];
   sprintf(f, "%s/%s", opt.datadir, file);
   DEBUG_INFO("Removing file %s\n", f);
-  opt.aiori->delete(f, opt.backend_opt);
+  opt.aiori->remove(f, opt.backend_opt);
 }
 
 void u_create_datadir(char const * dir){


### PR DESCRIPTION
With commit [bfc922f225](https://github.com/hpc/ior/commit/bfc922f22543b63a324ca7ef9f92c67dc24d1bdd) the aiori interface changes `delete` to `remove`. This commit adapts the IO500 code to this change.