### PR TITLE
Skip ior, pfind, schema-tools redownload for rebuild

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -53,19 +53,35 @@ function git_co {
 
 ###### GET FUNCTIONS
 function get_ior {
-  echo "Getting IOR and mdtest"
-  git_co https://github.com/hpc/ior.git ior $IOR_HASH
+  local ior_dir="build/ior"
+  if [ -d "$ior_dir" ]; then
+    echo "IOR already exists. Skipping download."
+  else
+    echo "Getting IOR and mdtest"
+    git_co https://github.com/hpc/ior.git "$ior_dir" $IOR_HASH
+  fi
 }
 
 function get_pfind {
-  echo "Preparing parallel find"
-  git_co https://github.com/VI4IO/pfind.git pfind $PFIND_HASH
+  local pfind_dir="build/pfind"
+  if [ -d "$pfind_dir" ]; then
+    echo "Parallel find already exists. Skipping download."
+  else
+    echo "Preparing parallel find"
+    git_co https://github.com/VI4IO/pfind.git "$pfind_dir" $PFIND_HASH
+  fi
 }
 
 function get_schema_tools {
-  echo "Downloading supplementary schema tools"
-  git_co https://github.com/VI4IO/cdcl-schema-tools.git cdcl-schema-tools
-  [ -d "$dir" ] || ln -sf "$PWD"/build/cdcl-schema-tools schema-tools
+  local schema_build_dir="build/cdcl-schema-tools"
+  local schema_dir="schema-tools"
+  if [ -d "$schema_build_dir" ] && [ -d "$schema_dir" ]; then
+    echo "Schema tools already exist. Skipping download."
+  else
+    echo "Downloading supplementary schema tools"
+    git_co https://github.com/VI4IO/cdcl-schema-tools.git cdcl-schema-tools
+    [ -d "$dir" ] || ln -sf "$PWD"/build/cdcl-schema-tools schema-tools
+  fi
 }
 
 ###### BUILD FUNCTIONS


### PR DESCRIPTION
Extended get_ior, get_pfind, get_schema_tools functions to only request internet access if necessary packages have not been downloaded yet. This prevents an error for rebuilds on compute nodes without internet access. The rebuild is often necessary since compute nodes cannot access the same libraries as login nodes.