### PR TITLE
Fix ior and pfind Directories In prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -53,7 +53,7 @@ function git_co {
 
 ###### GET FUNCTIONS
 function get_ior {
-  local ior_dir="build/ior"
+  local ior_dir="ior"
   if [ -d "$ior_dir" ]; then
     echo "IOR already exists. Skipping download."
   else
@@ -63,7 +63,7 @@ function get_ior {
 }
 
 function get_pfind {
-  local pfind_dir="build/pfind"
+  local pfind_dir="pfind"
   if [ -d "$pfind_dir" ]; then
     echo "Parallel find already exists. Skipping download."
   else


### PR DESCRIPTION
The `get_*` functions and `build_*` functions do not use the same path for ior and pfind. This recent commit puts the build artifacts into an additional /build directory.

```
# ls io500/build/
build  cdcl-schema-tools
# ls io500/build/build/
ior  pfind
```

```
./prepare.sh: line 89: pushd: /home/user/io500/build/ior: No such file or directory
```


- https://github.com/IO500/io500/issues/74