### PR TITLE
Bugfix for random read phase.

### DIFF
--- a/src/phase_ior.h
+++ b/src/phase_ior.h
@@ -41,7 +41,7 @@ extern opt_ior_rnd ior_rnd4K_o;
 extern opt_ior_rnd ior_rnd1MB_o;
 
 
-void ior_easy_add_params(u_argv_t * argv);
+void ior_easy_add_params(u_argv_t * argv, int addStdFlags);
 void ior_hard_add_params(u_argv_t * argv);
 void ior_rnd4K_add_params(u_argv_t * argv);
 void ior_rnd1MB_add_params(u_argv_t * argv);

--- a/src/phase_ior_easy.c
+++ b/src/phase_ior_easy.c
@@ -42,7 +42,7 @@ static void cleanup(void){
   }
 }
 
-void ior_easy_add_params(u_argv_t * argv){
+void ior_easy_add_params(u_argv_t * argv, int addStdFlags){
   opt_ior_easy d = ior_easy_o;
 
   u_argv_push(argv, "./ior");
@@ -66,12 +66,14 @@ void ior_easy_add_params(u_argv_t * argv){
   u_argv_push(argv, "-e");	/* fsync upon write close */
   u_argv_push(argv, "-o");	/* filename for output file */
   u_argv_push_printf(argv, "%s/ior-easy/ior_file_easy", opt.datadir);
-  u_argv_push(argv, "-O");	/* additional IOR options */
-  u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-easy.stonewall", opt.resdir);
-  u_argv_push(argv, "-t");	/* transfer size */
-  u_argv_push(argv, d.transferSize);
-  u_argv_push(argv, "-b");	/* blocksize in bytes */
-  u_argv_push(argv, d.blockSize);
+  if(addStdFlags){
+    u_argv_push(argv, "-O");	/* additional IOR options */
+    u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-easy.stonewall", opt.resdir);
+    u_argv_push(argv, "-t");	/* transfer size */
+    u_argv_push(argv, d.transferSize);
+    u_argv_push(argv, "-b");	/* blocksize in bytes */
+    u_argv_push(argv, d.blockSize);
+  }
 
   if(ior_easy_o.uniqueDir){
     u_argv_push(argv, "-u");	/* unique directory for each output file */

--- a/src/phase_ior_easy_read.c
+++ b/src/phase_ior_easy_read.c
@@ -30,7 +30,7 @@ static double run(void){
   opt_ior_easy d = ior_easy_o;
 
   u_argv_t * argv = u_argv_create();
-  ior_easy_add_params(argv);
+  ior_easy_add_params(argv, 1);
   u_argv_push(argv, "-r");	/* read existing file */
   u_argv_push(argv, "-R");	/* verify data read */
   u_argv_push_default_if_set_api_options(argv, "-a", d.api, o.api);

--- a/src/phase_ior_easy_write.c
+++ b/src/phase_ior_easy_write.c
@@ -29,7 +29,7 @@ static double run(void){
   opt_ior_easy d = ior_easy_o;
 
   u_argv_t * argv = u_argv_create();
-  ior_easy_add_params(argv);
+  ior_easy_add_params(argv, 1);
   u_argv_push(argv, "-w");	/* write file */
   u_argv_push(argv, "-D");	/* deadline for stonewall in seconds */
   u_argv_push_printf(argv, "%d", opt.stonewall);

--- a/src/phase_ior_rnd_read4k-easywrite.c
+++ b/src/phase_ior_rnd_read4k-easywrite.c
@@ -30,7 +30,7 @@ static double run(void){
   opt_ior_rnd_read d = o;
 
   u_argv_t * argv = u_argv_create();
-  ior_easy_add_params(argv);
+  ior_easy_add_params(argv, 0);
   u_argv_push(argv, "-r");
   u_argv_push(argv, "-D");
   u_argv_push_printf(argv, "%d", opt.stonewall);


### PR DESCRIPTION
At the moment it uses the segment count in the stonewall file from the easy-write-phase.

The intended behavior is that it uses the segment count specified - which usually is higher.