### PR TITLE
CODEOWNERS: change reviewers to @io500/board

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,39 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
-# For more info about this file, please see https://docs.github.com/en/enterprise/2.18/user/github/creating-cloning-and-archiving-repositories/about-code-owners
+# The pattern is followed by one or more GitHub usernames or team
+# names using the standard @username or @org/team-name format.
+# You can also refer to a user by an email address that has been
+# added to their GitHub Enterprise account, e.g. user@example.com.
+# These owners will be the default owners for everything in all
+# repos in the io500 org, unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+*       @io500/board
 
-# These owners will be the default owners for everything in
-# all repos in the io500 org.
-*       @adilger @gflofst @gmarkomanolis @seattleplus @JulianKunkel
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+#*.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+#*.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+#/build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+#docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+#apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+#/docs/ @doctocat


### PR DESCRIPTION
Change from explicitly listing each board member as a reviewer over to using the @io500/board group as the reviewer.  This adds @jeanbez to be notified for PRs instead of having to add him each time.

This is similar to how the io500/webpage CODEOWNERS is configured.