### PR TITLE
Bugfix for new 4k read write - allow for shared file.

### DIFF
--- a/src/phase_ior_easy.c
+++ b/src/phase_ior_easy.c
@@ -54,9 +54,6 @@ void ior_easy_add_params(u_argv_t * argv, int addStdFlags){
     u_argv_push(argv, "-O");
     u_argv_push(argv, "allocateBufferOnGPU=1");
   }
-  u_argv_push(argv, "-C");	/* reorder tasks in constant order for read */
-  u_argv_push(argv, "-Q");	/* task per node offset */
-  u_argv_push(argv, "1");
   u_argv_push(argv, "-g");	/* barriers between open, read, write, close */
   u_argv_push(argv, "-G");	/* use fixed timestamp signature */
   int hash = u_phase_unique_random_number("ior-easy");
@@ -67,6 +64,9 @@ void ior_easy_add_params(u_argv_t * argv, int addStdFlags){
   u_argv_push(argv, "-o");	/* filename for output file */
   u_argv_push_printf(argv, "%s/ior-easy/ior_file_easy", opt.datadir);
   if(addStdFlags){
+    u_argv_push(argv, "-C");	/* reorder tasks in constant order for read */
+    u_argv_push(argv, "-Q");	/* task per node offset */
+    u_argv_push(argv, "1");
     u_argv_push(argv, "-O");	/* additional IOR options */
     u_argv_push_printf(argv, "stoneWallingStatusFile=%s/ior-easy.stonewall", opt.resdir);
     u_argv_push(argv, "-t");	/* transfer size */

--- a/src/phase_ior_rnd_read4k-easywrite.c
+++ b/src/phase_ior_rnd_read4k-easywrite.c
@@ -27,7 +27,7 @@ static void validate(void){
 
 
 static double run(void){
-  opt_ior_rnd_read d = o;
+  opt_ior_easy d = ior_easy_o;
 
   u_argv_t * argv = u_argv_create();
   ior_easy_add_params(argv, 0);
@@ -44,6 +44,12 @@ static double run(void){
   u_argv_push(argv, "-s=10000000");
   u_argv_push(argv, "-O");
   u_argv_push(argv, "stoneWallingWearOut=1");
+
+  if (d.filePerProc){
+    u_argv_push(argv, "-C");	/* reorder tasks in constant order for read */
+    u_argv_push(argv, "-Q");	/* task per node offset */
+    u_argv_push(argv, "1");
+  }
   
   o.command = u_flatten_argv(argv);
 

--- a/src/phase_mdworkbench.c
+++ b/src/phase_mdworkbench.c
@@ -94,7 +94,9 @@ void mdworkbench_add_params(u_argv_t * argv, int is_create){
         if(! f){
           WARNING("Couldn't open mdworkbench-file: %s\n", file);
         }else{
-          fread(& mdtest->rate, sizeof(mdtest->rate), 1, f);
+          if (fread(& mdtest->rate, sizeof(mdtest->rate), 1, f) != 1) {
+            WARNING("Failed to read mdworkbench-file: %s\n", file);
+          }
         }
         fclose(f);
       }


### PR DESCRIPTION
This bugfix allows for usage of:
[ior-easy]
filePerProc = FALSE

It will avoid breaking the 4k read after write phase.

