### PR TITLE
Rename phase_ior_rnd_read4k-easywrite to phase_ior_rnd4k_easy_read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ vpath %.h $(SEARCHPATH)
 DEPS += io500-util.h io500-debug.h io500-opt.h
 OBJSO += util.o
 OBJSO += ini-parse.o phase_dbg.o phase_opt.o phase_timestamp.o
-OBJSO += phase_find.o phase_find_easy.o phase_find_hard.o phase_ior_easy.o phase_ior_easy_read.o phase_mdtest.o phase_ior.o phase_ior_easy_write.o phase_ior_hard.o phase_ior_hard_read.o phase_ior_hard_write.o phase_mdtest_easy.o phase_mdtest_easy_delete.o phase_mdtest_easy_stat.o phase_mdtest_easy_write.o phase_mdtest_hard.o phase_mdtest_hard_delete.o phase_mdtest_hard_read.o phase_mdtest_hard_stat.o phase_mdtest_hard_write.o phase_ior_rnd1MB.o phase_ior_rnd4K.o phase_ior_rnd_write4K.o phase_ior_rnd_read4K.o phase_ior_rnd_write1MB.o phase_ior_rnd_read1MB.o phase_mdworkbench.o phase_mdworkbench_create.o phase_mdworkbench_delete.o phase_mdworkbench_bench.o phase_ior_rnd_read4k-easywrite.o
+OBJSO += phase_find.o phase_find_easy.o phase_find_hard.o phase_ior_easy.o phase_ior_easy_read.o phase_mdtest.o phase_ior.o phase_ior_easy_write.o phase_ior_hard.o phase_ior_hard_read.o phase_ior_hard_write.o phase_mdtest_easy.o phase_mdtest_easy_delete.o phase_mdtest_easy_stat.o phase_mdtest_easy_write.o phase_mdtest_hard.o phase_mdtest_hard_delete.o phase_mdtest_hard_read.o phase_mdtest_hard_stat.o phase_mdtest_hard_write.o phase_ior_rnd1MB.o phase_ior_rnd4K.o phase_ior_rnd_write4K.o phase_ior_rnd_read4K.o phase_ior_rnd_write1MB.o phase_ior_rnd_read1MB.o phase_mdworkbench.o phase_mdworkbench_create.o phase_mdworkbench_delete.o phase_mdworkbench_bench.o phase_ior_rnd4k_easy_read.o
 
 OBJS = $(patsubst %,./build/%,$(OBJSO))
 

--- a/include/io500-phase.h
+++ b/include/io500-phase.h
@@ -68,7 +68,7 @@ extern u_phase_t p_mdworkbench_delete;
 extern u_phase_t p_ior_easy;
 extern u_phase_t p_ior_easy_write;
 extern u_phase_t p_ior_easy_read;
-extern u_phase_t p_ior_rnd4K_read_easywrite;
+extern u_phase_t p_ior_rnd4K_easy_read;
 
 extern u_phase_t p_mdtest_easy;
 extern u_phase_t p_mdtest_easy_write;

--- a/src/phase-definitions.h
+++ b/src/phase-definitions.h
@@ -47,7 +47,7 @@ static u_phase_t * phases[IO500_PHASES] = {
   & p_mdtest_easy_delete,
   & p_mdtest_hard_read,
   & p_mdtest_hard_delete,
-  & p_ior_rnd4K_read_easywrite
+  & p_ior_rnd4K_easy_read
 };
 
 static ini_section_t ** u_options(void){

--- a/src/phase_ior_rnd4k_easy_read.c
+++ b/src/phase_ior_rnd4k_easy_read.c
@@ -58,12 +58,12 @@ static double run(void){
     u_argv_free(argv);
     return 0;
   }
-  FILE * out = u_res_file_prep(p_ior_rnd4K_read_easywrite.name);
+  FILE * out = u_res_file_prep(p_ior_rnd4K_easy_read.name);
   return ior_process_read(argv, out, & o.res);
 }
 
 
-u_phase_t p_ior_rnd4K_read_easywrite = {
+u_phase_t p_ior_rnd4K_easy_read = {
   "ior-rnd4K-easy-read",
   IO500_PHASE_READ,
   option,


### PR DESCRIPTION
This PR renames the `ior-rnd4K-read-easywrite` phase (and its source file) to `ior-rnd4K-easy-read` to improve consistency and clarity in the codebase.

It updates:
* The source file name: `src/phase_ior_rnd_read4k-easywrite.c` -> `src/phase_ior_rnd4k_easy_read.c`
* The phase struct name: `p_ior_rnd4K_read_easywrite` -> `p_ior_rnd4K_easy_read`
* Related references in the `Makefile`, `io500-phase.h`, and `phase-definitions.h`.