### PR TITLE
Fix verifier score hash mismatch by excluding optional and unscored phases

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,10 @@
 
 #include <phase-definitions.h>
 
+bool should_hash_phase(char const * name) {
+  return u_should_hash_phase(name);
+}
+
 #define INVALID_RUN(...) do{ if (opt.rank == 0){fprintf(file_out, "; ERROR INVALID "__VA_ARGS__); printf("ERROR INVALID (%s:%d) ", __FILE__, __LINE__); printf(__VA_ARGS__); fflush(file_out); opt.is_valid_run = 0; } }while(0);
 
 #define RUN_PHASE(phase) ( ! (phase->type & IO500_PHASE_FLAG_OPTIONAL && opt.mode == IO500_MODE_STANDARD) )

--- a/src/phase-definitions.h
+++ b/src/phase-definitions.h
@@ -50,7 +50,7 @@ static u_phase_t * phases[IO500_PHASES] = {
   & p_ior_rnd4K_easy_read
 };
 
-static ini_section_t ** u_options(void){
+static inline ini_section_t ** u_options(void){
   ini_section_t ** ini_section = u_malloc(sizeof(ini_section_t*) * (IO500_PHASES + 1));
   for(int i=0; i < IO500_PHASES; i++){
     ini_section[i] = u_malloc(sizeof(ini_section_t));
@@ -60,3 +60,14 @@ static ini_section_t ** u_options(void){
   ini_section[IO500_PHASES] = NULL;
   return ini_section;
 }
+
+static inline bool u_should_hash_phase(char const * name) {
+  for (int i = 0; i < IO500_PHASES; i++) {
+    if (strcmp(phases[i]->name, name) == 0) {
+      return phases[i]->group > IO500_NO_SCORE &&
+             (phases[i]->type & IO500_PHASE_FLAG_OPTIONAL) == 0;
+    }
+  }
+  return true;
+}
+

--- a/src/util.c
+++ b/src/util.c
@@ -265,6 +265,10 @@ typedef struct{
 
 static res_file_data_t res_data;
 
+__attribute__((weak)) bool should_hash_phase(char const * name) {
+  return true;
+}
+
 static void hash_func(bool is_section, char const * key, char const * val){
   static char const * last_section = NULL;
   if(is_section){
@@ -299,6 +303,9 @@ static void hash_func(bool is_section, char const * key, char const * val){
     return;
   }
   if(strcmp(key, "score") == 0){
+    if (!should_hash_phase(last_section)) {
+      return;
+    }
     u_hash_update_key_val(& res_data.score_hash, last_section, val);
     return;
   }

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -8,6 +8,10 @@
 
 #include <phase-definitions.h>
 
+bool should_hash_phase(char const * name) {
+  return u_should_hash_phase(name);
+}
+
 // Dummy prototypes to satisfy need for depending modules
 // TODO use ifdefs to strip dependency
 void pfind_find(void){}


### PR DESCRIPTION
### Summary
This PR fixes a verification score hash mismatch by excluding optional and unscored phases when updating the score hash.

>>Before
$ ./io500 lm.ini  --verify ./results/2026.06.30-23.03.07/result.txt 
result file ver = eb0148f42189
[run]
config-hash     = 13955147
score-hash      = 5D9BF354

ERROR: Score hash expected: "F30160A3" read: "5D9BF354"

$ ./io500-verify lm.ini ./results/2026.06.30-23.03.07/result.txt 
version         = io500-isc26_v2-39
result file ver = eb0148f42189
[run]
config-hash     = 13955147
score-hash      = 5D9BF354

ERROR: Score hash expected: "F30160A3" read: "5D9BF354"
>>After
$ ./io500-verify lm.ini ./results/2026.06.30-23.03.07/result.txt 
version         = 58824bca65be-77
result file ver = eb0148f42189
[run]
config-hash     = 13955147
score-hash      = 5D9BF354

[OK]
$ ./io500 lm.ini  --verify ./results/2026.06.30-23.03.07/result.txt 
result file ver = eb0148f42189
[run]
config-hash     = 13955147
score-hash      = 5D9BF354

[OK]



### Details
- Updated `phase-definitions.h` with helper function `u_should_hash_phase()`.
- Updated `main.c` and `verifier.c` to export `should_hash_phase()`.
- Updated `util.c` with a weak fallback definition to maintain independence from phase definition modules in test builds.